### PR TITLE
show a different modal when approval transaction has completed

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -13,6 +13,8 @@ export function Modal({
   description,
   buttonText,
   buttonHref,
+  modalButtonAction,
+  modalButtonDisabled,
 }: {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
@@ -22,6 +24,8 @@ export function Modal({
   description?: string
   buttonText?: string
   buttonHref?: string
+  modalButtonAction?: () => void
+  modalButtonDisabled: boolean
 }) {
   // Disable auto-close for now
   // useEffect(() => {
@@ -94,10 +98,23 @@ export function Modal({
                   )}
 
                   {buttonText && buttonHref && (
-                    <div className="btn px-7 py-3 mb-8 text-lg text-center hover:cursor-pointer">
+                    <div className={`${
+                        modalButtonDisabled ? 'btn-disabled' : 'btn'} px-7 py-3 mb-8 text-lg text-center hover:cursor-pointer`}>
                       <Link to={buttonHref}>{buttonText}</Link>
                     </div>
                   )}
+
+                  {buttonText && modalButtonAction && (
+                    <button
+                      className={`${
+                        modalButtonDisabled ? 'btn-disabled' : 'btn'
+                      } px-7 py-3 mb-8 text-lg text-center`}
+                      onClick={modalButtonAction}
+                    >
+                      {buttonText}
+                    </button>
+                  )}
+                  
 
                   {txLink && (
                     <div className="mb-8">


### PR DESCRIPTION
[Notion Issue](https://www.notion.so/originprotocol/Prime-Staked-UI-Review-0-1-ef9af9181a2e46bdb795df0c8b067281?p=82e5a6b995b24b41b50fda82a2285ecf&pm=s)

Show a different modal when approval transaction has completed. This is now the experience when a user deposits an asset that needs an approval step 


<img width="582" alt="Screenshot 2024-02-05 at 23 26 51" src="https://github.com/oplabs/primestaked-ui/assets/579910/39cb0c80-12fb-4888-9627-d19ae8b7d179">
<img width="561" alt="Screenshot 2024-02-05 at 23 27 11" src="https://github.com/oplabs/primestaked-ui/assets/579910/9a94154a-b427-41ca-a1a8-f690b8fa357b">
<img width="568" alt="Screenshot 2024-02-05 at 23 27 22" src="https://github.com/oplabs/primestaked-ui/assets/579910/3b30bdae-eb02-4d19-95ed-d2a5a96f2209">
<img width="567" alt="Screenshot 2024-02-05 at 23 27 42" src="https://github.com/oplabs/primestaked-ui/assets/579910/9c7f3b55-40ec-45a2-bf71-eea79a606dcd">
<img width="562" alt="Screenshot 2024-02-05 at 23 28 38" src="https://github.com/oplabs/primestaked-ui/assets/579910/4b175f2e-242b-43eb-9c84-31ad76154f23">
